### PR TITLE
A quick fix for mac-osx error:  issue #1

### DIFF
--- a/ui-sys/build.rs
+++ b/ui-sys/build.rs
@@ -17,6 +17,6 @@ fn main() {
                         .unwrap();
 
     println!("cargo:rustc-link-lib=dylib=ui");
-    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-search={}", out_dir);
 }
 


### PR DESCRIPTION
The documentation from http://doc.crates.io/build-script.html 
says `cargo:rustc-link-search=native=/path/to/foo`

but projects I've used that has `c code` dependencies and successfully build and run mac osx like [`rusqlite`](https://github.com/jgallagher/rusqlite/blob/master/libsqlite3-sys/build.rs)
uses `cargo:rustc-link-search={}` without the `=native`

Removing `native` in [`build.rs`](https://github.com/pcwalton/libui-rs/blob/master/ui-sys/build.rs) solves the issue https://github.com/pcwalton/libui-rs/issues/1

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pcwalton/libui-rs/2)

<!-- Reviewable:end -->
