### PR TITLE
Update upstream libui to alpha3, fix controlgallery example

### DIFF
--- a/ui-sys/src/lib.rs
+++ b/ui-sys/src/lib.rs
@@ -228,7 +228,14 @@ extern {
                                 f: extern "C" fn(c: *mut uiCombobox, data: *mut c_void),
                                 data: *mut c_void);
     pub fn uiNewCombobox() -> *mut uiCombobox;
-    pub fn uiNewEditableCombobox() -> *mut uiCombobox;
+}
+
+pub enum uiEditableCombobox {}
+
+#[link(name = "ui")]
+extern {
+    pub fn uiEditableComboboxAppend(c: *mut uiEditableCombobox, text: *const c_char);
+    pub fn uiNewEditableCombobox() -> *mut uiEditableCombobox;
 }
 
 pub enum uiRadioButtons {}

--- a/ui/examples/controlgallery.rs
+++ b/ui/examples/controlgallery.rs
@@ -2,8 +2,8 @@
 
 extern crate ui;
 
-use ui::{BoxControl, Button, Checkbox, ColorButton, Combobox, DateTimePicker, Entry};
-use ui::{FontButton, Group, InitOptions, Label, Menu, MenuItem, ProgressBar, RadioButtons};
+use ui::{BoxControl, Button, Checkbox, ColorButton, Combobox, DateTimePicker, EditableCombobox};
+use ui::{Entry, FontButton, Group, InitOptions, Label, Menu, MenuItem, ProgressBar, RadioButtons};
 use ui::{Separator, Slider, Spinbox, Tab, Window};
 
 fn run() {
@@ -97,11 +97,11 @@ fn run() {
     cbox.append("Combobox Item 3");
     inner.append(cbox.into(), false);
 
-    let cbox = Combobox::new_editable();
-    cbox.append("Editable Item 1");
-    cbox.append("Editable Item 2");
-    cbox.append("Editable Item 3");
-    inner.append(cbox.into(), false);
+    let ecbox = EditableCombobox::new();
+    ecbox.append("Editable Item 1");
+    ecbox.append("Editable Item 2");
+    ecbox.append("Editable Item 3");
+    inner.append(ecbox.into(), false);
 
     let rb = RadioButtons::new();
     rb.append("Radio Button 1");

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -10,8 +10,9 @@ extern crate libc;
 extern crate ui_sys;
 
 pub use controls::{Area, AreaDrawParams, AreaHandler, BoxControl, Button, Checkbox, ColorButton};
-pub use controls::{Combobox, Control, DateTimePicker, Entry, FontButton, Group, Label};
-pub use controls::{MultilineEntry, ProgressBar, RadioButtons, Separator, Slider, Spinbox, Tab};
+pub use controls::{Combobox, Control, DateTimePicker, EditableCombobox, Entry, FontButton, Group};
+pub use controls::{Label, MultilineEntry, ProgressBar, RadioButtons, Separator, Slider, Spinbox};
+pub use controls::Tab;
 pub use ffi_utils::Text;
 pub use menus::{Menu, MenuItem};
 pub use ui::{InitError, InitOptions, init, main, msg_box, msg_box_error, on_should_quit};


### PR DESCRIPTION
And fixed `controlgallery.rs` example since it crashes with new `EditableCombobox` control.

Didn't update to libui master, because they changed the build system to CMake, so that requires a larger change.
