### PR TITLE
Make Control impl Send

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 ui-sys/target
 ui-sys/Cargo.lock
-ui-sys/libui
 ui/target
 ui/Cargo.lock
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+ui-sys/target
+ui-sys/Cargo.lock
+ui-sys/libui
+ui/target
+ui/Cargo.lock
+.DS_Store
+*.bk

--- a/ui-sys/build.rs
+++ b/ui-sys/build.rs
@@ -1,22 +1,51 @@
 extern crate make_cmd;
 
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::fs::{self, File};
+use std::io::Write;
 
 fn main() {
     if !Path::new("libui/.git").exists() {
-        Command::new("git").args(&["submodule", "update", "--init"]).status().unwrap();
+        Command::new("git").args(&["submodule", "update", "--init"]).status().expect("Could not update libui submodule");
     }
-
+    
+    let cwd = env::current_dir().unwrap();
+    
+    let libui_path = cwd.join("libui");
+    env::set_current_dir(&libui_path).expect("Could not change dir");
+    
+    // Run CMake
+    //let cmake_cache_path = (&libui_path).join("CMakeCache.txt");
+    //if cmake_cache_path.exists() {
+    //    fs::remove_file(cmake_cache_path).expect("Could not remove cmake cache");
+    //}
+    Command::new("cmake").arg(".").output().expect("cmake failed");
+    
+    // Run Make
+    let libui_out_path = (&libui_path).join("out");
+    if ! libui_out_path.exists() {
+        println!("Creating out dir");
+        fs::create_dir(&libui_out_path).expect("Could not create out dir");
+    }
+    make_cmd::gnu_make().status().expect("Make failed");
+    
+    // Copy the output to the build folder
     let out_dir = env::var("OUT_DIR").unwrap();
-    let outdir_argument = format!("OUTDIR={}", out_dir);
-    let objdir_argument = format!("OBJDIR={}/obj", out_dir);
-    make_cmd::gnu_make().args(&["-C", "libui", &*outdir_argument, &*objdir_argument])
-                        .status()
-                        .unwrap();
+    let out_path = Path::new(&out_dir);
+    for entry in fs::read_dir(&libui_out_path).unwrap() {
+        let entry = entry.expect("IO error while reading");
+        let name = entry.file_name();
+        let target = out_path.join(name);
+        fs::copy(&entry.path(), &target).expect("Could not copy file");
+        println!("Copying file from {} to {}", entry.path().display(), target.display());
+    }
+    
 
+    // Configure cargo
     println!("cargo:rustc-link-lib=dylib=ui");
-    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-search={}", out_dir);
+    //panic!();
 }
 

--- a/ui-sys/build.rs
+++ b/ui-sys/build.rs
@@ -7,6 +7,7 @@ use std::fs::{self, File};
 use std::io::Write;
 
 fn main() {
+    println!("cargo:rerun-if-changed=libui");
     if !Path::new("libui/.git").exists() {
         Command::new("git").args(&["submodule", "update", "--init"]).status().expect("Could not update libui submodule");
     }

--- a/ui/src/controls.rs
+++ b/ui/src/controls.rs
@@ -24,6 +24,10 @@ macro_rules! define_control {
             $ui_field: *mut $ui_type,
         }
 
+        unsafe impl ::std::marker::Send for $rust_type {
+
+        }
+
         impl ::std::ops::Deref for $rust_type {
             type Target = ::controls::Control;
 


### PR DESCRIPTION
This will allow controls to be cloned and reused from other threads. I'm not sure how to make this Rust-y, though, because perhaps each `Control` needs some more guarantees before it can `impl Send`.

Either way, it's working for me locally, so maybe it's useful for all
