### PR TITLE
Use cmake to build libui, rename link target ui -> libui.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ui-sys/libui"]
 	path = ui-sys/libui
-	url = https://github.com/andlabs/libui
+	url = https://github.com/zentner-kyle/libui

--- a/ui-sys/Cargo.toml
+++ b/ui-sys/Cargo.toml
@@ -10,5 +10,4 @@ description = "Native bindings to the minimalist, cross-platform, widget set `li
 libc = "0.2"
 
 [build-dependencies]
-make-cmd = "0.1"
-
+cmake = "0.1.22"

--- a/ui-sys/src/ffi.rs
+++ b/ui-sys/src/ffi.rs
@@ -10,7 +10,6 @@ pub struct uiInitOptions {
     pub Size: size_t,
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiInit(options: *mut uiInitOptions) -> *const c_char;
     pub fn uiUninit();
@@ -45,7 +44,6 @@ pub struct uiControl {
     pub Disable: extern "C" fn(this: *mut uiControl),
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiControlDestroy(control: *mut uiControl);
     pub fn uiControlHandle(control: *mut uiControl) -> usize;
@@ -70,7 +68,6 @@ extern {
 
 pub enum uiWindow {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiWindowTitle(w: *mut uiWindow) -> *mut c_char;
     pub fn uiWindowSetTitle(w: *mut uiWindow, title: *const c_char);
@@ -86,7 +83,6 @@ extern {
 
 pub enum uiButton {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiButtonText(b: *mut uiButton) -> *mut c_char;
     pub fn uiButtonSetText(b: *mut uiButton, text: *const c_char);
@@ -98,7 +94,6 @@ extern {
 
 pub enum uiBox {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiBoxAppend(b: *mut uiBox, child: *mut uiControl, stretchy: c_int);
     pub fn uiBoxDelete(b: *mut uiBox, index: uintmax_t);
@@ -110,7 +105,6 @@ extern {
 
 pub enum uiEntry {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiEntryText(e: *mut uiEntry) -> *mut c_char;
     pub fn uiEntrySetText(e: *mut uiEntry, text: *const c_char);
@@ -124,7 +118,6 @@ extern {
 
 pub enum uiCheckbox {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiCheckboxText(c: *mut uiCheckbox) -> *mut c_char;
     pub fn uiCheckboxSetText(c: *mut uiCheckbox, text: *const c_char);
@@ -138,7 +131,6 @@ extern {
 
 pub enum uiLabel {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiLabelText(l: *mut uiLabel) -> *mut c_char;
     pub fn uiLabelSetText(l: *mut uiLabel, text: *const c_char);
@@ -147,7 +139,6 @@ extern {
 
 pub enum uiTab {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiTabAppend(t: *mut uiTab, name: *const c_char, c: *mut uiControl);
     pub fn uiTabInsertAt(t: *mut uiTab, name: *const c_char, before: uintmax_t, c: *mut uiControl);
@@ -160,7 +151,6 @@ extern {
 
 pub enum uiGroup {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiGroupTitle(g: *mut uiGroup) -> *mut c_char;
     pub fn uiGroupSetTitle(g: *mut uiGroup, title: *const c_char);
@@ -172,7 +162,6 @@ extern {
 
 pub enum uiSpinbox {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiSpinboxValue(s: *mut uiSpinbox) -> intmax_t;
     pub fn uiSpinboxSetValue(s: *mut uiSpinbox, value: intmax_t);
@@ -184,7 +173,6 @@ extern {
 
 pub enum uiProgressBar {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiProgressBarSetValue(p: *mut uiProgressBar, n: c_int);
     pub fn uiNewProgressBar() -> *mut uiProgressBar;
@@ -192,7 +180,6 @@ extern {
 
 pub enum uiSlider {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiSliderValue(s: *mut uiSlider) -> intmax_t;
     pub fn uiSliderSetValue(s: *mut uiSlider, value: intmax_t);
@@ -204,14 +191,12 @@ extern {
 
 pub enum uiSeparator {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiNewHorizontalSeparator() -> *mut uiSeparator;
 }
 
 pub enum uiCombobox {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiComboboxAppend(c: *mut uiCombobox, text: *const c_char);
     pub fn uiComboboxSelected(c: *mut uiCombobox) -> intmax_t;
@@ -225,7 +210,6 @@ extern {
 
 pub enum uiRadioButtons {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiRadioButtonsAppend(r: *mut uiRadioButtons, text: *const c_char);
     pub fn uiNewRadioButtons() -> *mut uiRadioButtons;
@@ -233,7 +217,6 @@ extern {
 
 pub enum uiDateTimePicker {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiNewDateTimePicker() -> *mut uiDateTimePicker;
     pub fn uiNewDatePicker() -> *mut uiDateTimePicker;
@@ -242,7 +225,6 @@ extern {
 
 pub enum uiMultilineEntry {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiMultilineEntryText(e: *mut uiMultilineEntry) -> *mut c_char;
     pub fn uiMultilineEntrySetText(e: *mut uiMultilineEntry, text: *const c_char);
@@ -257,7 +239,6 @@ extern {
 
 pub enum uiMenuItem {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiMenuItemEnable(m: *mut uiMenuItem);
     pub fn uiMenuItemDisable(m: *mut uiMenuItem);
@@ -272,7 +253,6 @@ extern {
 
 pub enum uiMenu {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiMenuAppendItem(m: *mut uiMenu, name: *const c_char) -> *mut uiMenuItem;
     pub fn uiMenuAppendCheckItem(m: *mut uiMenu, name: *const c_char) -> *mut uiMenuItem;
@@ -283,7 +263,6 @@ extern {
     pub fn uiNewMenu(name: *const c_char) -> *mut uiMenu;
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiOpenFile(parent: *mut uiWindow) -> *mut c_char;
     pub fn uiSaveFile(parent: *mut uiWindow) -> *mut c_char;
@@ -311,7 +290,6 @@ pub struct uiAreaHandler {
                                 -> c_int,
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiAreaSetSize(a: *mut uiArea, width: intmax_t, height: intmax_t);
     pub fn uiAreaQueueRedrawAll(a: *mut uiArea);
@@ -434,13 +412,11 @@ pub struct uiDrawStrokeParams {
     pub DashPhase: c_double,
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiDrawNewPath(fillMode: uiDrawFillMode) -> *mut uiDrawPath;
     pub fn uiDrawFreePath(p: *mut uiDrawPath);
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiDrawPathNewFigure(p: *mut uiDrawPath, x: c_double, y: c_double);
     pub fn uiDrawPathNewFigureWithArc(p: *mut uiDrawPath,
@@ -705,7 +681,6 @@ pub struct uiAreaKeyEvent {
 
 pub enum uiFontButton {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiFontButtonFont(b: *mut uiFontButton) -> *mut uiDrawTextFont;
     pub fn uiFontButtonOnChanged(b: *mut uiFontButton,
@@ -716,7 +691,6 @@ extern {
 
 pub enum uiColorButton {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiColorButtonColor(b: *mut uiColorButton,
                               r: *mut c_double,
@@ -733,4 +707,3 @@ extern {
                                   data: *mut c_void);
     pub fn uiNewColorButton() -> *mut uiColorButton;
 }
-

--- a/ui-sys/src/lib.rs
+++ b/ui-sys/src/lib.rs
@@ -18,7 +18,6 @@ pub struct uiInitOptions {
     pub Size: size_t,
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiInit(options: *mut uiInitOptions) -> *const c_char;
     pub fn uiUninit();
@@ -53,7 +52,6 @@ pub struct uiControl {
     pub Disable: extern "C" fn(this: *mut uiControl),
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiControlDestroy(control: *mut uiControl);
     pub fn uiControlHandle(control: *mut uiControl) -> usize;
@@ -78,7 +76,6 @@ extern {
 
 pub enum uiWindow {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiWindowTitle(w: *mut uiWindow) -> *mut c_char;
     pub fn uiWindowSetTitle(w: *mut uiWindow, title: *const c_char);
@@ -94,7 +91,6 @@ extern {
 
 pub enum uiButton {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiButtonText(b: *mut uiButton) -> *mut c_char;
     pub fn uiButtonSetText(b: *mut uiButton, text: *const c_char);
@@ -106,7 +102,6 @@ extern {
 
 pub enum uiBox {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiBoxAppend(b: *mut uiBox, child: *mut uiControl, stretchy: c_int);
     pub fn uiBoxDelete(b: *mut uiBox, index: uintmax_t);
@@ -118,7 +113,6 @@ extern {
 
 pub enum uiEntry {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiEntryText(e: *mut uiEntry) -> *mut c_char;
     pub fn uiEntrySetText(e: *mut uiEntry, text: *const c_char);
@@ -132,7 +126,6 @@ extern {
 
 pub enum uiCheckbox {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiCheckboxText(c: *mut uiCheckbox) -> *mut c_char;
     pub fn uiCheckboxSetText(c: *mut uiCheckbox, text: *const c_char);
@@ -146,7 +139,6 @@ extern {
 
 pub enum uiLabel {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiLabelText(l: *mut uiLabel) -> *mut c_char;
     pub fn uiLabelSetText(l: *mut uiLabel, text: *const c_char);
@@ -155,7 +147,6 @@ extern {
 
 pub enum uiTab {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiTabAppend(t: *mut uiTab, name: *const c_char, c: *mut uiControl);
     pub fn uiTabInsertAt(t: *mut uiTab, name: *const c_char, before: uintmax_t, c: *mut uiControl);
@@ -168,7 +159,6 @@ extern {
 
 pub enum uiGroup {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiGroupTitle(g: *mut uiGroup) -> *mut c_char;
     pub fn uiGroupSetTitle(g: *mut uiGroup, title: *const c_char);
@@ -180,7 +170,6 @@ extern {
 
 pub enum uiSpinbox {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiSpinboxValue(s: *mut uiSpinbox) -> intmax_t;
     pub fn uiSpinboxSetValue(s: *mut uiSpinbox, value: intmax_t);
@@ -192,7 +181,6 @@ extern {
 
 pub enum uiProgressBar {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiProgressBarSetValue(p: *mut uiProgressBar, n: c_int);
     pub fn uiNewProgressBar() -> *mut uiProgressBar;
@@ -200,7 +188,6 @@ extern {
 
 pub enum uiSlider {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiSliderValue(s: *mut uiSlider) -> intmax_t;
     pub fn uiSliderSetValue(s: *mut uiSlider, value: intmax_t);
@@ -212,14 +199,12 @@ extern {
 
 pub enum uiSeparator {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiNewHorizontalSeparator() -> *mut uiSeparator;
 }
 
 pub enum uiCombobox {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiComboboxAppend(c: *mut uiCombobox, text: *const c_char);
     pub fn uiComboboxSelected(c: *mut uiCombobox) -> intmax_t;
@@ -233,7 +218,6 @@ extern {
 
 pub enum uiRadioButtons {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiRadioButtonsAppend(r: *mut uiRadioButtons, text: *const c_char);
     pub fn uiNewRadioButtons() -> *mut uiRadioButtons;
@@ -241,7 +225,6 @@ extern {
 
 pub enum uiDateTimePicker {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiNewDateTimePicker() -> *mut uiDateTimePicker;
     pub fn uiNewDatePicker() -> *mut uiDateTimePicker;
@@ -250,7 +233,6 @@ extern {
 
 pub enum uiMultilineEntry {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiMultilineEntryText(e: *mut uiMultilineEntry) -> *mut c_char;
     pub fn uiMultilineEntrySetText(e: *mut uiMultilineEntry, text: *const c_char);
@@ -265,7 +247,6 @@ extern {
 
 pub enum uiMenuItem {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiMenuItemEnable(m: *mut uiMenuItem);
     pub fn uiMenuItemDisable(m: *mut uiMenuItem);
@@ -280,7 +261,6 @@ extern {
 
 pub enum uiMenu {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiMenuAppendItem(m: *mut uiMenu, name: *const c_char) -> *mut uiMenuItem;
     pub fn uiMenuAppendCheckItem(m: *mut uiMenu, name: *const c_char) -> *mut uiMenuItem;
@@ -291,7 +271,6 @@ extern {
     pub fn uiNewMenu(name: *const c_char) -> *mut uiMenu;
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiOpenFile(parent: *mut uiWindow) -> *mut c_char;
     pub fn uiSaveFile(parent: *mut uiWindow) -> *mut c_char;
@@ -319,7 +298,6 @@ pub struct uiAreaHandler {
                                 -> c_int,
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiAreaSetSize(a: *mut uiArea, width: intmax_t, height: intmax_t);
     pub fn uiAreaQueueRedrawAll(a: *mut uiArea);
@@ -442,13 +420,11 @@ pub struct uiDrawStrokeParams {
     pub DashPhase: c_double,
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiDrawNewPath(fillMode: uiDrawFillMode) -> *mut uiDrawPath;
     pub fn uiDrawFreePath(p: *mut uiDrawPath);
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiDrawPathNewFigure(p: *mut uiDrawPath, x: c_double, y: c_double);
     pub fn uiDrawPathNewFigureWithArc(p: *mut uiDrawPath,
@@ -713,7 +689,6 @@ pub struct uiAreaKeyEvent {
 
 pub enum uiFontButton {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiFontButtonFont(b: *mut uiFontButton) -> *mut uiDrawTextFont;
     pub fn uiFontButtonOnChanged(b: *mut uiFontButton,
@@ -724,7 +699,6 @@ extern {
 
 pub enum uiColorButton {}
 
-#[link(name = "ui")]
 extern {
     pub fn uiColorButtonColor(b: *mut uiColorButton,
                               r: *mut c_double,
@@ -741,4 +715,3 @@ extern {
                                   data: *mut c_void);
     pub fn uiNewColorButton() -> *mut uiColorButton;
 }
-

--- a/ui-sys/src/platform/macos/mod.rs
+++ b/ui-sys/src/platform/macos/mod.rs
@@ -23,7 +23,6 @@ pub struct uiDarwinControl {
                                           NSLayoutConstraintOrientation),
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiDarwinControlSyncEnableState(control: *mut uiDarwinControl, state: c_int);
     pub fn uiDarwinControlSetSuperview(control: *mut uiDarwinControl, view: *mut NSView);
@@ -59,4 +58,3 @@ pub const NSLayoutPriorityWindowSizeStayPut: NSLayoutPriority = 500.0;
 pub const NSLayoutPriorityDragThatCannotResizeWindow: NSLayoutPriority = 490.0;
 pub const NSLayoutPriorityDefaultLow: NSLayoutPriority = 250.0;
 pub const NSLayoutPriorityFittingSizeCompression: NSLayoutPriority = 50.0;
-

--- a/ui-sys/src/platform/unix/mod.rs
+++ b/ui-sys/src/platform/unix/mod.rs
@@ -14,7 +14,6 @@ pub struct uiUnixControl {
     pub SetContainer: extern "C" fn(*mut uiUnixControl, *mut GtkContainer, gboolean),
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiUnixControlSetContainer(control: *mut uiUnixControl,
                                      container: *mut GtkContainer,
@@ -29,4 +28,3 @@ pub type gboolean = gint;
 pub type gint = c_int;
 
 pub enum GtkContainer {}
-

--- a/ui-sys/src/platform/windows/mod.rs
+++ b/ui-sys/src/platform/windows/mod.rs
@@ -19,7 +19,6 @@ pub struct uiWindowsControl {
     pub AssignControlIDZOrder: extern "C" fn(*mut uiWindowsControl, *mut LONG_PTR, *mut HWND),
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiWindowsControlSyncEnableState(control: *mut uiWindowsControl, state: c_int);
     pub fn uiWindowsControlSetParentHWND(control: *mut uiWindowsControl, parent: HWND);
@@ -105,7 +104,6 @@ pub struct uiWindowsSizing {
     pub InternalLeading: LONG,
 }
 
-#[link(name = "ui")]
 extern {
     pub fn uiWindowsGetSizing(hwnd: HWND, sizing: *mut uiWindowsSizing);
     pub fn uiWindowsSizingDlgUnitsToPixels(sizing: *mut uiWindowsSizing,
@@ -179,4 +177,3 @@ pub type UINT_PTR = c_uint;
 pub type WCHAR = wchar_t;
 
 pub type WORD = c_ushort;
-


### PR DESCRIPTION
This updates libui to the latest version in upstream, with a commit from me to make MSVC builds work in release mode.

I've tested that the examples still build under MSVC, Linux, and OSX.

Unfortunately, the examples nearly instantly crash on OSX.